### PR TITLE
Change ownership

### DIFF
--- a/cli/find.go
+++ b/cli/find.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 // The purpose of the 'find' command is more to 'explore' the schema and searching for something in a broad way. 'GET', however, is used if you already know what you need to lookup and do a specific search.

--- a/cli/fmt.go
+++ b/cli/fmt.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func fmtCommand() {

--- a/cli/get.go
+++ b/cli/get.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
-	"github.com/erikkn/klaabu/klaabu"
 	"log"
 	"os"
+
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func getCommand() {

--- a/cli/init.go
+++ b/cli/init.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func initCommand() {

--- a/cli/space.go
+++ b/cli/space.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	"github.com/erikkn/klaabu/klaabu"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"log"
 	"os"
 	"sort"
+
+	"github.com/transferwise/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 func spaceCommand() {

--- a/cli/terraform.go
+++ b/cli/terraform.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
-	"github.com/erikkn/klaabu/klaabu/terraform"
+	"github.com/transferwise/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu/terraform"
 )
 
 func exportTerraformCommand() {

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 func validateCommand() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/erikkn/klaabu
+module github.com/transferwise/klaabu
 
 go 1.15

--- a/klaabu/kml.go
+++ b/klaabu/kml.go
@@ -3,9 +3,10 @@ package klaabu
 import (
 	"errors"
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/kml"
 	"io"
 	"os"
+
+	"github.com/transferwise/klaabu/klaabu/kml"
 )
 
 const (

--- a/klaabu/kml/marshal.go
+++ b/klaabu/kml/marshal.go
@@ -1,10 +1,11 @@
 package kml
 
 import (
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 type ColumnWidths struct {

--- a/klaabu/prefix.go
+++ b/klaabu/prefix.go
@@ -2,8 +2,9 @@ package klaabu
 
 import (
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"sort"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 // Cidr represents a single CIDR notation.

--- a/klaabu/terraform/terraform.go
+++ b/klaabu/terraform/terraform.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"encoding/json"
 
-	"github.com/erikkn/klaabu/klaabu"
+	"github.com/transferwise/klaabu/klaabu"
 )
 
 type module struct {

--- a/klaabu/validate.go
+++ b/klaabu/validate.go
@@ -2,8 +2,9 @@ package klaabu
 
 import (
 	"fmt"
-	"github.com/erikkn/klaabu/klaabu/iputil"
 	"net"
+
+	"github.com/transferwise/klaabu/klaabu/iputil"
 )
 
 // MinMaxIP lalala.


### PR DESCRIPTION
Former maintainer of this tool has left the company. Ownership was transferred to the `transferwise` org, this PR updates the package names to reflect these changes. This is necessary to make `go get` work with this package.